### PR TITLE
feature: Generate job token for simulator usage

### DIFF
--- a/config.example.json
+++ b/config.example.json
@@ -1,5 +1,6 @@
 {
     "BCRYPT_LOG_ROUNDS": 12,
     "AUTH_KEY": "my_precious",
+    "JOB_KEY": "my_precious",
     "SQLALCHEMY_DATABASE_URI": "postgres://sg:sg@auth_database/sg"
 }

--- a/connection/models.py
+++ b/connection/models.py
@@ -36,7 +36,7 @@ class User(db.Model):
 
     def encode_auth_token(self, user_id, name):
         """
-        Generates the Auth Token
+        Generates an Auth Token
         :return: string
         """
         try:
@@ -54,6 +54,26 @@ class User(db.Model):
         except Exception as e:
             return e
 
+    def encode_job_token(self, job_id):
+        """
+        Generates a Job Token
+        :return: string
+        """
+        try:
+            payload = {
+                "exp": datetime.datetime.utcnow()
+                + datetime.timedelta(days=30, seconds=0),
+                "iat": datetime.datetime.utcnow(),
+                "sub": self.id,
+                "name": self.username,
+                "job_id": job_id,
+            }
+            return jwt.encode(
+                payload, current_app.config.get("JOB_KEY"), algorithm="HS256"
+            )
+        except Exception as e:
+            return e
+
     @staticmethod
     def decode_auth_token(auth_token):
         """
@@ -67,7 +87,7 @@ class User(db.Model):
             if is_blacklisted_token:
                 return "Token blacklisted. Please log in again."
             else:
-                return payload["sub"]
+                return payload
         except jwt.ExpiredSignatureError:
             return "Signature expired. Please log in again."
         except jwt.InvalidTokenError:

--- a/routes/__init__.py
+++ b/routes/__init__.py
@@ -2,7 +2,7 @@
 Routes module
 """
 
-from .auth_routes import RegisterApi, LoginApi, UserApi, LogoutApi
+from .auth_routes import RegisterApi, LoginApi, UserApi, LogoutApi, TokenApi
 from .fake_routes import TestData
 
 
@@ -14,6 +14,7 @@ def set_up_routes(app, api):
     api.add_resource(RegisterApi, "/auth/register")
     api.add_resource(LoginApi, "/auth/login")
     api.add_resource(UserApi, "/auth/status")
+    api.add_resource(TokenApi, "/auth/token")
     api.add_resource(LogoutApi, "/auth/logout")
 
     # Only while in development

--- a/tests/config.testing.json
+++ b/tests/config.testing.json
@@ -1,5 +1,6 @@
 {
     "BCRYPT_LOG_ROUNDS": 12,
     "AUTH_KEY": "my_precious",
+    "JOB_KEY": "my_precious",
     "SQLALCHEMY_DATABASE_URI": "sqlite://"
 }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,6 @@
+import pytest
+
+
+def pytest_namespace():
+    return {"auth_token": None}
+


### PR DESCRIPTION
Support https://github.com/alan-turing-institute/simulate/issues/103.

The auth server can be called upon to generate "simulator tokens". These contain a "job_id". A simulator token can be used by the simulator to gain access to the manager even after the original user's token has been blacklisted, however the simulator token can only be used for the job_id it was assigned to. 